### PR TITLE
Fix Clipboard crashes with ExternalException

### DIFF
--- a/Windows/Main.cs
+++ b/Windows/Main.cs
@@ -865,7 +865,7 @@ namespace NX_Game_Info
 
                 if (text.Any() && !text.All(x => String.IsNullOrEmpty(x)))
                 {
-                    Clipboard.SetText(String.Join("\n", text));
+                    Clipboard.SetDataObject(new DataObject(DataFormats.Text, String.Join("\n", text)));
                 }
                 else
                 {


### PR DESCRIPTION
Got ExternalException on clipboard copy once, can't reproduce but it seems setdataobjet will help with 10 automatic retries spaced by 100ms